### PR TITLE
Do not use TIMEOUT_MAX for Condition.wait()

### DIFF
--- a/imaplib2/imaplib2.py
+++ b/imaplib2/imaplib2.py
@@ -67,7 +67,6 @@ if bytes != str:
 else:
     import Queue as queue
     string_types = basestring
-    threading.TIMEOUT_MAX = 9223372036854.0
 
 select_module = select
 
@@ -192,7 +191,7 @@ class Request(object):
     def get_response(self, exc_fmt=None):
         self.callback = None
         if __debug__: self.parent._log(3, '%s:%s.ready.wait' % (self.name, self.tag))
-        self.ready.wait(threading.TIMEOUT_MAX)
+        self.ready.wait()
 
         if self.aborted is not None:
             typ, val = self.aborted
@@ -1391,7 +1390,7 @@ class IMAP4(object):
             self.commands_lock.release()
             if need_event:
                 if __debug__: self._log(3, 'sync command %s waiting for empty commands Q' % name)
-                self.state_change_free.wait(threading.TIMEOUT_MAX)
+                self.state_change_free.wait()
                 if __debug__: self._log(3, 'sync command %s proceeding' % name)
 
         if self.state not in Commands[name][CMD_VAL_STATES]:

--- a/imaplib2/imaplib2.py3
+++ b/imaplib2/imaplib2.py3
@@ -182,7 +182,7 @@ class Request(object):
     def get_response(self, exc_fmt=None):
         self.callback = None
         if __debug__: self.parent._log(3, '%s:%s.ready.wait' % (self.name, self.tag))
-        self.ready.wait(threading.TIMEOUT_MAX)
+        self.ready.wait()
 
         if self.aborted is not None:
             typ, val = self.aborted
@@ -1316,7 +1316,7 @@ class IMAP4(object):
             self.commands_lock.release()
             if need_event:
                 if __debug__: self._log(3, 'sync command %s waiting for empty commands Q' % name)
-                self.state_change_free.wait(threading.TIMEOUT_MAX)
+                self.state_change_free.wait()
                 if __debug__: self._log(3, 'sync command %s proceeding' % name)
 
         if self.state not in Commands[name][CMD_VAL_STATES]:


### PR DESCRIPTION
On some architectures, using threading.TIMEOUT_MAX for the timeout parameter can overflow causing Condition.wait() to return immediately.

As an example, running the following will block on amd64 but return immediately on  i386:
```python
Python 3.6.6 (default, Jun 27 2018, 14:44:17)
[GCC 8.1.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import threading
>>> ready = threading.Event()                                                                        
>>> ready.wait(threading.TIMEOUT_MAX)                                                                
False
```

Instead of relying on TIMEOUT_MAX, remove it and wait forever. This patch should fix #2 and #3.

