### PR TITLE
Remove crash if debug is set and port is not set

### DIFF
--- a/imaplib2/imaplib2.py3
+++ b/imaplib2/imaplib2.py3
@@ -337,7 +337,7 @@ class IMAP4(object):
 
         if __debug__:
             if debug:
-                self._mesg('connected to %s on port %s' % (self.host, self.port))
+                self._mesg('connected to %s on port %s' % (host, port))
 
         # Threading
 


### PR DESCRIPTION
If the debug argument is set, then this block is executed:

```python
 if __debug __:
     if debug:
         self._mesg('connected to %s on port %s' % (self.host, self.port))
```

The variables `self.host` and `self.port` are not set yet, then imaplib2
will crash with a __getattr() __ function error:

```python-traceback
  File "/usr/lib/python3/dist-packages/imaplib2.py", line 340, in __init __
    self._mesg('connected to %s on port %s' % (self.host, self.port))
  File "/usr/lib/python3/dist-packages/imaplib2.py", line 404, in __getattr __
    raise AttributeError("Unknown IMAP4 command: '%s'" % attr)
```

We can solve this problem changing the `self.host` to host and `self.port`
to port, like this:

```python
 if __debug __:
     if debug:
         self._mesg('connected to %s on port %s' % (host, port))
```

Then the problem is solved.

Closes #10