### PR TITLE
add version() to access __version__ for the python 3 version

### DIFF
--- a/imaplib2/imaplib2.py3
+++ b/imaplib2/imaplib2.py3
@@ -16,7 +16,7 @@ Public functions: Internaldate2Time
 
 __all__ = ("IMAP4", "IMAP4_SSL", "IMAP4_stream",
            "Internaldate2Time", "ParseFlags", "Time2Internaldate",
-           "Mon2num", "MonthNames", "InternalDate")
+           "Mon2num", "MonthNames", "InternalDate", "__version__")
 
 __version__ = "3.06"
 __release__ = "3"
@@ -1370,7 +1370,7 @@ class IMAP4(object):
             self.ouq.put(rqb)
             return rqb
 
-        # Must setup continuation expectancy *before* ouq.put 
+        # Must setup continuation expectancy *before* ouq.put
         crqb = self._request_push(name=name, tag='continuation')
 
         self.ouq.put(rqb)
@@ -2554,7 +2554,7 @@ if __name__ == '__main__':
             run('id', ())
             run('id', ("(name imaplib2)",))
             run('id', ("version", __version__, "os", os.uname()[0]))
- 
+
         for cmd,args in test_seq2:
             if (cmd,args) != ('uid', ('SEARCH', 'SUBJECT', 'IMAP4 test')):
                 run(cmd, args)

--- a/imaplib2/imaplib2.py3
+++ b/imaplib2/imaplib2.py3
@@ -16,7 +16,7 @@ Public functions: Internaldate2Time
 
 __all__ = ("IMAP4", "IMAP4_SSL", "IMAP4_stream",
            "Internaldate2Time", "ParseFlags", "Time2Internaldate",
-           "Mon2num", "MonthNames", "InternalDate", "__version__")
+           "Mon2num", "MonthNames", "InternalDate", "version")
 
 __version__ = "3.06"
 __release__ = "3"
@@ -136,6 +136,26 @@ Commands = {
         }
 
 UID_direct = ('SEARCH', 'SORT', 'THREAD')
+
+
+def version(use_tuple=False):
+    """Return the version of this module.
+
+    Arguments
+    ---------
+    use_tuple : bool
+        Whether to return a string or a tuple of (major, minor). When True, the major and minor in the tuple will be
+        integers rather than strings.
+
+    Returns
+    -------
+    The version.
+    """
+
+    if use_tuple:
+        return (int(__release__), int(__revision__))
+
+    return __version__
 
 
 def Int2AP(num):
@@ -1370,7 +1390,7 @@ class IMAP4(object):
             self.ouq.put(rqb)
             return rqb
 
-        # Must setup continuation expectancy *before* ouq.put
+        # Must setup continuation expectancy *before* ouq.put 
         crqb = self._request_push(name=name, tag='continuation')
 
         self.ouq.put(rqb)
@@ -2554,7 +2574,7 @@ if __name__ == '__main__':
             run('id', ())
             run('id', ("(name imaplib2)",))
             run('id', ("version", __version__, "os", os.uname()[0]))
-
+ 
         for cmd,args in test_seq2:
             if (cmd,args) != ('uid', ('SEARCH', 'SUBJECT', 'IMAP4 test')):
                 run(cmd, args)


### PR DESCRIPTION
Currently when `__init__.py` does `from .imaplib2 import *`, `__version__` is not imported because it is not in `__all__`. However, **_offlineimap 3_** requires this variable to under the top-level package name of `imaplib2`. See line 75 in `offlineimap3/init.py`: https://github.com/OfflineIMAP/offlineimap3/blob/1e7ef9e7e6952f5d29ef0f5c25fd062798de55f3/offlineimap/init.py#L75

~This PR adds `__version__` to `__all__`.~

This PR adds a function `version()` to `imaplib2.py3` to access `__version__`. The plan is to modify the offlineimap 3 to use this `version()` function.