### PR TITLE
Export module metadata on wrapper module

### DIFF
--- a/imaplib2/__init__.py
+++ b/imaplib2/__init__.py
@@ -1,3 +1,4 @@
 from __future__ import absolute_import
 
 from .imaplib2 import *
+from .imaplib2 import __version__, __doc__


### PR DESCRIPTION
Explicitly import __version__ and __doc__ into wrapper module.

Makes `help(imaplib2)` work like intended and lets other module check the version if needed