### PR TITLE
Add a 'reference' documentation section

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,3 +38,9 @@ jobs:
           flags: py${{ matrix.python-version }}
           fail_ci_if_error: true
           verbose: true
+      - name: Install docs dependencies
+        working-directory: docs
+        run: pip install --requirement requirements.txt
+      - name: Build docs
+        working-directory: docs
+        run: make html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,9 +10,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
 
 
 # -- Project information -----------------------------------------------------
@@ -31,6 +31,7 @@ release = '3.06'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx.ext.autodoc',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,10 @@ Python threaded IMAP4 client module ``imaplib2``
    :maxdepth: 2
    :caption: Contents:
 
+   reference
+
+.. contents:: :local:
+
 This module defines a class, ``IMAP4``, which encapsulates a threaded
 connection to an IMAP4 server and implements the IMAP4rev1 client
 protocol as defined in RFC 3501 with several extensions. This module

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1,0 +1,4 @@
+Library Reference
+=================
+
+.. autofunction:: imaplib2.version

--- a/imaplib2/imaplib2.py
+++ b/imaplib2/imaplib2.py
@@ -139,17 +139,15 @@ UID_direct = ('SEARCH', 'SORT', 'THREAD')
 
 
 def version(use_tuple=False):
-    """Return the version of this module.
+    """
+    Return the version of this module, either as a single string (the default) or a :class:`tuple`
+    of ``major_version, minor_version`` as integers
 
-    Arguments
-    ---------
-    use_tuple : bool
-        Whether to return a string or a tuple of (major, minor). When True, the major and minor in the tuple will be
-        integers rather than strings.
-
-    Returns
-    -------
-    The version.
+    :param use_tuple: Whether to return :class:`tuple`
+    :type use_tuple: :class:`bool`
+    :return: The version of this library, the format depends on the value of ``use_tuple``
+    :rtype: (:class:`int`, :class:`int`) if ``use_tuple``
+    :rtype: :class:`str` otherwise
     """
 
     if use_tuple:


### PR DESCRIPTION
This is a followup to #30

- Add a 'reference' documentation section

    This file contains documentation generated from the library's pydocs. As
    an example, rewrite the docs for `imaplib2.version` into a Sphinx
    compatible format and link to it using Sphinx's `autodoc` extension[1].

    [1] https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html

- Add CI job to build docs

    Since docs will be built from source, this job is to help catch any
    errors e.g. introduced by someone changing pydocs who didn't try to
    rebuild the docs locally