### PR TITLE
Use resp_timeout for socket connection

### DIFF
--- a/imaplib2/imaplib2.py
+++ b/imaplib2/imaplib2.py
@@ -468,7 +468,7 @@ class IMAP4(object):
         """open_socket()
         Open socket choosing first address family available."""
 
-        return socket.create_connection((self.host, self.port))
+        return socket.create_connection((self.host, self.port), self.resp_timeout)
 
 
     def ssl_wrap_socket(self):


### PR DESCRIPTION
There is actually no easy way to set the timeout for the first socket connection.
We could just use the `resp_timeout` attribute of the IMAP4 class. Otherwise we could add another parameter to `__init__`.