### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,11 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
+
+- repo: https://github.com/codespell-project/codespell
+  # Configuration for codespell is in pyproject.toml
+  rev: v2.2.6
+  hooks:
+  - id: codespell
+    additional_dependencies:
+    - tomli

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -229,7 +229,7 @@ An ``IMAP4`` instance has the following methods:
    List *subscribed* mailbox names in directory matching pattern.
    Returned *data* are tuples of message part envelope and data.
 ``myrights``\ (*mailbox*)
-   Show my Access Controll Lists for *mailbox* (i.e. the rights that I
+   Show my Access Control Lists for *mailbox* (i.e. the rights that I
    have on *mailbox*).
 ``namespace``\ ()
    Returns IMAP namespaces per RFC2342.

--- a/imaplib2/imaplib2.py
+++ b/imaplib2/imaplib2.py
@@ -782,7 +782,7 @@ class IMAP4(object):
     def enable(self, capability):
         """Send an RFC5161 enable string to the server.
 
-        (typ, [data]) = <intance>.enable(capability)
+        (typ, [data]) = <instance>.enable(capability)
         """
         if 'ENABLE' not in self.capabilities:
             raise self.error("Server does not support ENABLE")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,10 @@ deps =
 commands =
     pytest {posargs}
 """
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*'
+check-hidden = true
+# ignore-regex = ''
+ignore-words-list = 'donn'


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.