### PR TITLE
Tolerate multiple spaces in status message

### DIFF
--- a/imaplib2/imaplib2.py
+++ b/imaplib2/imaplib2.py
@@ -301,7 +301,7 @@ class IMAP4(object):
 
     # These must be encoded according to utf8 setting in _mode_xxx():
     _literal = br'.*{(?P<size>\d+)}$'
-    _untagged_status = br'\* (?P<data>\d+) (?P<type>[A-Z-]+)( (?P<data2>.*))?'
+    _untagged_status = br'\*[ ]+(?P<data>\d+) (?P<type>[A-Z-]+)( (?P<data2>.*))?'
 
     continuation_cre = re.compile(br'\+( (?P<data>.*))?')
     mapCRLF_cre = re.compile(br'\r\n|\r|\n')


### PR DESCRIPTION
Somewhere between Microsoft exchange and DavMail I've started getting multiple spaces in IMAP responses to EXAMINE. These are not conformant to the standard but in case somebody else needs to tolerate these, here is a patch.

I've marked this as draft as I'm not sure if you want to merge non-conformant behaviour .