### PR TITLE
Remove socket sslerror

### DIFF
--- a/imaplib2/imaplib2.py
+++ b/imaplib2/imaplib2.py
@@ -526,7 +526,7 @@ class IMAP4(object):
             self.read_fd = self.sock.fileno()
         except ImportError:
             # No ssl module, and socket.ssl has no fileno(), and does not allow certificate verification
-            raise socket.sslerror("imaplib SSL mode does not work without ssl module")
+            raise ImportError("imaplib SSL mode does not work without ssl module")
 
         if self.cert_verify_cb is not None:
             cert_err = self.cert_verify_cb(self.sock.getpeercert(), self.host)

--- a/imaplib2/imaplib2.py
+++ b/imaplib2/imaplib2.py
@@ -507,7 +507,7 @@ class IMAP4(object):
                 raise RuntimeError("unknown tls_level: %s" % self.tls_level)
 
             if self.ssl_version not in TLS_MAP[self.tls_level]:
-                raise ValueError("Invalid SSL version '%s' requested for tls_version '%s'" % (self.ssl_version, self.tls_level))
+                raise ValueError("Invalid SSL version '%s' requested for tls_level '%s'" % (self.ssl_version, self.tls_level))
 
             ssl_version =  TLS_MAP[self.tls_level][self.ssl_version]
 

--- a/imaplib2/imaplib2.py
+++ b/imaplib2/imaplib2.py
@@ -507,7 +507,7 @@ class IMAP4(object):
                 raise RuntimeError("unknown tls_level: %s" % self.tls_level)
 
             if self.ssl_version not in TLS_MAP[self.tls_level]:
-                raise socket.sslerror("Invalid SSL version '%s' requested for tls_version '%s'" % (self.ssl_version, self.tls_level))
+                raise ValueError("Invalid SSL version '%s' requested for tls_version '%s'" % (self.ssl_version, self.tls_level))
 
             ssl_version =  TLS_MAP[self.tls_level][self.ssl_version]
 


### PR DESCRIPTION
Hi Everyone,

First, thank you for maintaining this library!

This PR addresses issue https://github.com/jazzband/imaplib2/issues/36 

The code currently raises `socket.sslerror()`, which is no longer available in Python 3 (ref. Python socket module [documentation](https://docs.python.org/3/library/socket.html)).

Rather than replacing it directly with `ssl.SSLError`, I updated the exception types to reflect the underlying conditions:

- `ValueError` is raised when validating an invalid SSL/TLS configuration value
- `ImportError` is raised when the `ssl` module is unavailable

My reasoning is that these cases represent configuration or import failures rather than SSL protocol errors, so the more specific exceptions seemed appropriate.

Please let me know if you prefer a different approach. I'm happy to make any requested changes.